### PR TITLE
Add notification microservice with RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This Wallet Service is a critical component designed to manage user funds with h
 - Depositing funds into wallets
 - Withdrawing funds from wallets
 - Transferring funds between wallets
+- Notifying users of transactions via RabbitMQ
 
 The service is built with Java 17 and Spring Boot 3.5.0, following best practices for production-ready applications.
 
@@ -149,6 +150,17 @@ This project uses `SpringDoc OpenAPI` to automatically generate interactive API 
    http://localhost:8080/v3/api-docs
    ```
 - ⚠️ Important: Swagger UI is disabled by default in production for security reasons.
+
+## Notification Service
+
+Transactions generate messages on RabbitMQ. The separate **notificarion-service**
+listens to these messages and logs a notification for the users involved in each
+operation. Both sender and receiver of a transfer are notified.
+
+- Queue: `wallet.notification.queue`
+- Exchange: `wallet.notification.exchange`
+- Routing Key: `wallet.notification.key`
+
 
 ## API Documentation
 
@@ -388,6 +400,7 @@ The service is designed as a standalone Spring Boot application that can be depl
 - **API**: Spring Web, SpringDoc OpenAPI 2.7.0.
 - **Testing**: JUnit 5, Mockito, Spring Boot Test.
 - **Containerization**: Docker and Docker Compose.
+- **Messaging**: RabbitMQ for transaction notifications.
 
 ### Data Model Design
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,6 +15,28 @@ services:
       - wallet-network-dev
     restart: unless-stopped
 
+  notification:
+    build:
+      context: ./notificarion-service
+      dockerfile: Dockerfile
+    image: notificarion-service:latest
+    container_name: notificarion-service-dev
+    depends_on:
+      - rabbitmq
+    networks:
+      - wallet-network-dev
+    restart: unless-stopped
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq-dev
+    ports:
+      - "5673:5672"
+      - "15673:15672"
+    networks:
+      - wallet-network-dev
+    restart: unless-stopped
+
 networks:
   wallet-network-dev:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,28 @@ services:
       - wallet-network
     restart: unless-stopped
 
+  notification:
+    build:
+      context: ./notificarion-service
+      dockerfile: Dockerfile
+    image: notificarion-service:latest
+    container_name: notificarion-service
+    depends_on:
+      - rabbitmq
+    networks:
+      - wallet-network
+    restart: unless-stopped
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - wallet-network
+    restart: unless-stopped
+
   postgres:
     image: postgres:14-alpine
     container_name: wallet-postgres

--- a/notificarion-service/Dockerfile
+++ b/notificarion-service/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3.8.3-openjdk-17-slim AS build
+WORKDIR /app
+
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+COPY src ./src
+RUN mvn package -DskipTests
+
+FROM amazoncorretto:17-alpine-jdk
+WORKDIR /app
+COPY --from=build /app/target/notificarion-service-1.0.0-SNAPSHOT.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/notificarion-service/pom.xml
+++ b/notificarion-service/pom.xml
@@ -8,79 +8,42 @@
         <version>3.4.5</version>
         <relativePath/>
     </parent>
-    <groupId>com.wallet</groupId>
-    <artifactId>wallet-service</artifactId>
+    <groupId>com.notificarion</groupId>
+    <artifactId>notificarion-service</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <name>Wallet Service</name>
-    <description>A wallet service for managing user funds</description>
-    
+    <name>Notificarion Service</name>
+
     <properties>
         <java.version>17</java.version>
     </properties>
-    
+
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <artifactId>spring-boot-starter</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.7.0</version>
-        </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
             </plugin>
         </plugins>
     </build>
 </project>
-

--- a/notificarion-service/src/main/java/com/notificarion/service/NotificarionServiceApplication.java
+++ b/notificarion-service/src/main/java/com/notificarion/service/NotificarionServiceApplication.java
@@ -1,0 +1,12 @@
+package com.notificarion.service;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NotificarionServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(NotificarionServiceApplication.class, args);
+    }
+}

--- a/notificarion-service/src/main/java/com/notificarion/service/config/RabbitMQConfig.java
+++ b/notificarion-service/src/main/java/com/notificarion/service/config/RabbitMQConfig.java
@@ -1,0 +1,31 @@
+package com.notificarion.service.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String EXCHANGE = "wallet.notification.exchange";
+    public static final String QUEUE = "wallet.notification.queue";
+    public static final String ROUTING_KEY = "wallet.notification.key";
+
+    @Bean
+    public Queue queue() {
+        return new Queue(QUEUE, true);
+    }
+
+    @Bean
+    public TopicExchange exchange() {
+        return new TopicExchange(EXCHANGE);
+    }
+
+    @Bean
+    public Binding binding(Queue queue, TopicExchange exchange) {
+        return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
+    }
+}

--- a/notificarion-service/src/main/java/com/notificarion/service/dto/NotificationMessage.java
+++ b/notificarion-service/src/main/java/com/notificarion/service/dto/NotificationMessage.java
@@ -1,0 +1,16 @@
+package com.notificarion.service.dto;
+
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+public class NotificationMessage {
+    private Long userId;
+    private UUID walletId;
+    private String type;
+    private BigDecimal amount;
+    private UUID referenceId;
+    private String description;
+}

--- a/notificarion-service/src/main/java/com/notificarion/service/listener/TransactionListener.java
+++ b/notificarion-service/src/main/java/com/notificarion/service/listener/TransactionListener.java
@@ -1,0 +1,19 @@
+package com.notificarion.service.listener;
+
+import com.notificarion.service.dto.NotificationMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import static com.notificarion.service.config.RabbitMQConfig.QUEUE;
+
+@Slf4j
+@Component
+public class TransactionListener {
+
+    @RabbitListener(queues = QUEUE)
+    public void handleNotification(NotificationMessage message) {
+        log.info("Received notification for user {} - wallet {} : {} {}", message.getUserId(), message.getWalletId(), message.getType(), message.getAmount());
+        // Here you could send an email, push notification, etc.
+    }
+}

--- a/notificarion-service/src/main/resources/application.properties
+++ b/notificarion-service/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest
+
+logging.level.org.springframework=INFO
+logging.level.com.notificarion.service=DEBUG

--- a/src/main/java/com/wallet/service/config/RabbitMQConfig.java
+++ b/src/main/java/com/wallet/service/config/RabbitMQConfig.java
@@ -1,0 +1,31 @@
+package com.wallet.service.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String EXCHANGE = "wallet.notification.exchange";
+    public static final String QUEUE = "wallet.notification.queue";
+    public static final String ROUTING_KEY = "wallet.notification.key";
+
+    @Bean
+    public Queue walletQueue() {
+        return new Queue(QUEUE, true);
+    }
+
+    @Bean
+    public TopicExchange walletExchange() {
+        return new TopicExchange(EXCHANGE);
+    }
+
+    @Bean
+    public Binding walletBinding(Queue walletQueue, TopicExchange walletExchange) {
+        return BindingBuilder.bind(walletQueue).to(walletExchange).with(ROUTING_KEY);
+    }
+}

--- a/src/main/java/com/wallet/service/messaging/NotificationMessage.java
+++ b/src/main/java/com/wallet/service/messaging/NotificationMessage.java
@@ -1,0 +1,20 @@
+package com.wallet.service.messaging;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationMessage {
+    private Long userId;
+    private UUID walletId;
+    private String type;
+    private BigDecimal amount;
+    private UUID referenceId;
+    private String description;
+}

--- a/src/main/java/com/wallet/service/messaging/NotificationPublisher.java
+++ b/src/main/java/com/wallet/service/messaging/NotificationPublisher.java
@@ -1,0 +1,19 @@
+package com.wallet.service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import static com.wallet.service.config.RabbitMQConfig.EXCHANGE;
+import static com.wallet.service.config.RabbitMQConfig.ROUTING_KEY;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publish(NotificationMessage message) {
+        rabbitTemplate.convertAndSend(EXCHANGE, ROUTING_KEY, message);
+    }
+}

--- a/src/main/java/com/wallet/service/service/impl/WalletServiceImpl.java
+++ b/src/main/java/com/wallet/service/service/impl/WalletServiceImpl.java
@@ -12,6 +12,8 @@ import com.wallet.service.model.Wallet;
 import com.wallet.service.repository.TransactionRepository;
 import com.wallet.service.repository.WalletRepository;
 import com.wallet.service.service.WalletService;
+import com.wallet.service.messaging.NotificationMessage;
+import com.wallet.service.messaging.NotificationPublisher;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +37,7 @@ public class WalletServiceImpl implements WalletService {
 
     private final WalletRepository walletRepository;
     private final TransactionRepository transactionRepository;
+    private final NotificationPublisher notificationPublisher;
 
     @Override
     @Transactional
@@ -117,8 +120,17 @@ public class WalletServiceImpl implements WalletService {
             transaction.setBalanceAfter(wallet.getBalance());
             Transaction savedTransaction = transactionRepository.save(transaction);
             transactionRepository.flush();
-            
+
             log.info("Deposit completed successfully. Transaction ID: {}", savedTransaction.getId());
+
+            notificationPublisher.publish(new NotificationMessage(
+                    wallet.getUserId(),
+                    wallet.getId(),
+                    TransactionType.DEPOSIT.name(),
+                    request.getAmount(),
+                    savedTransaction.getReferenceId(),
+                    request.getDescription()));
+
             return mapToTransactionResponse(savedTransaction);
         } catch (Exception e) {
             log.error("Deposit failed", e);
@@ -157,6 +169,15 @@ public class WalletServiceImpl implements WalletService {
             transactionRepository.flush();
             
             log.info("Withdrawal completed successfully. Transaction ID: {}", savedTransaction.getId());
+
+            notificationPublisher.publish(new NotificationMessage(
+                    wallet.getUserId(),
+                    wallet.getId(),
+                    TransactionType.WITHDRAWAL.name(),
+                    request.getAmount(),
+                    savedTransaction.getReferenceId(),
+                    request.getDescription()));
+
             return mapToTransactionResponse(savedTransaction);
         } catch (Exception e) {
             log.error("Withdrawal failed", e);
@@ -215,7 +236,23 @@ public class WalletServiceImpl implements WalletService {
             Transaction savedDestinationTransaction = transactionRepository.save(destinationTransaction);
             
             log.info("Transfer completed successfully. Reference ID: {}", referenceId);
-            
+
+            notificationPublisher.publish(new NotificationMessage(
+                    sourceWallet.getUserId(),
+                    sourceWallet.getId(),
+                    TransactionType.TRANSFER_OUT.name(),
+                    request.getAmount(),
+                    referenceId,
+                    request.getDescription()));
+
+            notificationPublisher.publish(new NotificationMessage(
+                    destinationWallet.getUserId(),
+                    destinationWallet.getId(),
+                    TransactionType.TRANSFER_IN.name(),
+                    request.getAmount(),
+                    referenceId,
+                    request.getDescription()));
+
             List<TransactionResponse> responses = new ArrayList<>();
             responses.add(mapToTransactionResponse(savedSourceTransaction));
             responses.add(mapToTransactionResponse(savedDestinationTransaction));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,9 @@ logging.level.org.springframework=INFO
 logging.level.com.wallet.service=DEBUG
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+# RabbitMQ
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest


### PR DESCRIPTION
## Summary
- integrate RabbitMQ in wallet-service
- send notifications on deposit, withdrawal and transfer
- add new `notificarion-service` microservice to listen for events
- update Docker compose files to include RabbitMQ and the new service
- document messaging support in README

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684654f3a0f08331b20ccef6a17d6a43