### PR TITLE
Add observability stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Approximately 7 hours and 20 minutes.
   - [Docker Mode](#docker-mode)
 - [API Documentation](#api-documentation)
 - [Testing](#testing)
+- [Observability](#observability)
 - [Design Decisions](#design-decisions)
 - [Trade-offs and Limitations](#trade-offs-and-limitations)
 
@@ -366,6 +367,17 @@ The tests cover:
 - API endpoints (integration tests)
 - Edge cases and error handling
 
+## Observability
+
+The service provides built-in observability leveraging the following components:
+
+- **Prometheus** collects metrics exposed by Spring Boot Actuator.
+- **Grafana** offers dashboards and alerting using Prometheus and Loki data sources.
+- **Loki** stores application logs sent through a Logback appender.
+- **Zipkin** receives distributed tracing data produced via Micrometer Tracing.
+
+All of these services are defined in the provided Docker Compose files. After running `docker-compose up`, you can access Grafana at http://localhost:3000 and Zipkin at http://localhost:9411.
+
 ## Design Decisions
 
 ### Architecture Overview
@@ -465,7 +477,7 @@ The current implementation does not include a caching layer. For very high read 
 
 ### Monitoring and Alerting
 
-The service does not include built-in monitoring and alerting capabilities. In a production environment, it would be integrated with monitoring tools (e.g., Prometheus, Grafana) to track performance metrics, health, and generate alerts on anomalies.
+The service includes a basic observability stack with Prometheus, Grafana, Loki and Zipkin configured via Docker Compose. These tools collect metrics, traces and logs from the application, enabling dashboards and alerting rules to be created as needed.
 
 ---
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -11,9 +11,50 @@ services:
       - "8080:8080"
     environment:
       - SPRING_PROFILES_ACTIVE=dev
+      - MANAGEMENT_ZIPKIN_TRACING_ENDPOINT=http://zipkin:9411/api/v2/spans
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
     networks:
       - wallet-network-dev
     restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus-dev
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - wallet-network-dev
+    depends_on:
+      - app
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana-dev
+    ports:
+      - "3000:3000"
+    networks:
+      - wallet-network-dev
+    depends_on:
+      - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki-dev
+    ports:
+      - "3100:3100"
+    networks:
+      - wallet-network-dev
+
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: zipkin-dev
+    ports:
+      - "9411:9411"
+    networks:
+      - wallet-network-dev
 
 networks:
   wallet-network-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,12 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/walletdb
       - SPRING_DATASOURCE_USERNAME=postgres
       - SPRING_DATASOURCE_PASSWORD=postgres
+      - MANAGEMENT_ZIPKIN_TRACING_ENDPOINT=http://zipkin:9411/api/v2/spans
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
     depends_on:
       - postgres
+      - zipkin
+      - loki
     networks:
       - wallet-network
     restart: unless-stopped
@@ -34,6 +38,45 @@ services:
     networks:
       - wallet-network
     restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - wallet-network
+    depends_on:
+      - app
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - wallet-network
+    depends_on:
+      - prometheus
+      - loki
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - "3100:3100"
+    networks:
+      - wallet-network
+
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: zipkin
+    ports:
+      - "9411:9411"
+    networks:
+      - wallet-network
 
 networks:
   wallet-network:

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,29 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Observability dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-reporter-brave</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.loki4j</groupId>
+            <artifactId>loki-logback-appender</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'wallet-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['app:8080']

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,11 @@ logging.level.org.springframework=INFO
 logging.level.com.wallet.service=DEBUG
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+# Actuator and Prometheus
+management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoint.health.show-details=always
+
+# Tracing
+management.tracing.sampling.probability=1.0
+management.zipkin.tracing.endpoint=${MANAGEMENT_ZIPKIN_TRACING_ENDPOINT:http://localhost:9411/api/v2/spans}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <appender name="LOKI" class="com.github.loki4j.logback.LokiAppender">
+        <lokiUrl>${LOKI_URL:-http://localhost:3100/loki/api/v1/push}</lokiUrl>
+        <format>json</format>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="LOKI"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- integrate Spring Actuator, Micrometer, Zipkin and Loki for metrics, tracing and log shipping
- expose Prometheus metrics and configure tracing via application properties
- provide Prometheus, Grafana, Loki and Zipkin services in Docker Compose with sample Prometheus config and documentation updates

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_689d1e7deee88331b0ced440f0df2ee1